### PR TITLE
Fix build sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -43,7 +43,7 @@ done
 if [[ -z $OUTPUT || (-z $DARWIN && -z $LINUX && -z $WINDOWS) ]];
 then
     echo $USAGE;
-    exit 1
+    exit 1;
 fi
 
 build_os_pkg() {


### PR DESCRIPTION
Reviewer: @EwiththeBowtie 

Our internal build system differentiates between `bash` and `sh`, so we need to set the `#!` in `scripts/build.sh` to `/bin/bash` instead of `/bin/sh`. That was a change I made that worked locally, because my `/bin/sh` is an alias to `/bin/bash`, but does not work on our build servers.