### PR TITLE
 Nested Static Property Set Values

### DIFF
--- a/examples/static-property-set/main.tf
+++ b/examples/static-property-set/main.tf
@@ -1,0 +1,55 @@
+// Commented out for Terraform 0.12
+
+terraform {
+  required_providers {
+    onefuse = {
+      source  = "CloudBoltSoftware/onefuse"
+      version = ">= 1.1.0"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
+// Comment out above for Terraform 0.12
+
+
+// Inititalize OneFuse Provider
+provider "onefuse" {
+  scheme     = "https"
+  address    = "onefuse_fqdn"
+  port       = "port"
+  user       = "admin"
+  password   = "admin"
+  verify_ssl = "false"
+}
+
+// Static Property Set
+// We expect a Static Property Set called SPS01 with the following content:
+// {
+//   "someKey": "someValue",
+//   "parent": {
+//     "someNestedKey": "someNestedValue"
+//   }
+// }
+//
+data "onefuse_static_property_set" "sps01" {
+    name = "SPS01"
+}
+
+// Only top-level key:value (string:string) pairs
+output "some_value" {
+  value = data.onefuse_static_property_set.sps01.properties
+}
+
+// All key:value pairs, arbitrary nesting allowed
+output "raw_value" {
+  value = data.onefuse_static_property_set.sps01.raw
+}
+
+locals  {
+  some_nested_value = jsondecode(data.onefuse_static_property_set.sps01.raw).parent.someNestedKey
+}
+
+output "some_nested_value" {
+  value = local.some_nested_value
+}

--- a/onefuse/api_client.go
+++ b/onefuse/api_client.go
@@ -187,6 +187,7 @@ type StaticPropertySet struct {
 	Name        string                 `json:"name,omitempty"`
 	Description string                 `json:"description,omitempty"`
 	Properties  map[string]interface{} `json:"properties,omitempty"`
+	Raw         string
 }
 
 type IPAMPolicyResponse struct {
@@ -308,19 +309,19 @@ type ScriptingDeployment struct {
 		Workspace   LinkRef `json:"workspace,omitempty"`
 		Policy      LinkRef `json:"policy,omitempty"`
 		JobMetadata LinkRef `json:"jobMetadata,omitempty"`
-	} `json:"_links, omitempty"`
+	} `json:"_links,omitempty"`
 	ID                  int    `json:"id,omitempty"`
 	PolicyID            int    `json:"policyId,omitempty"`
 	Policy              string `json:"policy,omitempty"`
 	WorkspaceURL        string `json:"workspace,omitempty"`
 	Hostname            string `json:"hostname,omitempty"`
 	ProvisioningDetails *struct {
-		status string   `json:"status"`
-		output []string `json:"output"`
+		Status string   `json:"status"`
+		Output []string `json:"output"`
 	} `json:"provisioningDetails:omitempty"`
 	DeprovisioningDetails *struct {
-		status string   `json:"status"`
-		output []string `json:"output"`
+		Status string   `json:"status"`
+		Output []string `json:"output"`
 	} `json:"deprovisioningDetails:omitempty"`
 	Archived           bool                   `json:"archived,omitempty"`
 	TemplateProperties map[string]interface{} `json:"templateProperties"`
@@ -1112,7 +1113,15 @@ func (apiClient *OneFuseAPIClient) GetStaticPropertySetByName(name string) (*Sta
 	if err != nil {
 		return nil, err
 	}
+
 	staticPropertySet := entity.(StaticPropertySet)
+
+	raw, err := json.Marshal(staticPropertySet.Properties)
+	if err != nil {
+		return nil, err
+	}
+	staticPropertySet.Raw = string(raw)
+
 	return &staticPropertySet, nil
 }
 

--- a/onefuse/data_source_fuse_static_property_set.go
+++ b/onefuse/data_source_fuse_static_property_set.go
@@ -38,6 +38,10 @@ func dataSourceStaticPropertySet() *schema.Resource {
 				Type:     schema.TypeMap,
 				Computed: true,
 			},
+			"raw": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -57,6 +61,7 @@ func dataSourceStaticPropertySetRead(d *schema.ResourceData, meta interface{}) e
 	d.SetId(strconv.Itoa(staticPropertySet.ID))
 	d.Set("name", staticPropertySet.Name)
 	d.Set("properties", staticPropertySet.Properties)
+	d.Set("raw", staticPropertySet.Raw)
 
 	return nil
 }

--- a/onefuse/resource_fuse_dns_reservation.go
+++ b/onefuse/resource_fuse_dns_reservation.go
@@ -52,10 +52,10 @@ func resourceDNSReservation() *schema.Resource {
 				Optional: true,
 			},
 		},
-                Timeouts: &schema.ResourceTimeout{
-                        Create: schema.DefaultTimeout(5 * time.Minute),
-                        Delete: schema.DefaultTimeout(5 * time.Minute),
-                },
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
 	}
 }
 

--- a/onefuse/resource_fuse_ipam_reservation.go
+++ b/onefuse/resource_fuse_ipam_reservation.go
@@ -100,10 +100,10 @@ func resourceIPAMReservation() *schema.Resource {
 				Optional: true,
 			},
 		},
-                Timeouts: &schema.ResourceTimeout{
-                        Create: schema.DefaultTimeout(5 * time.Minute),
-                        Delete: schema.DefaultTimeout(5 * time.Minute),
-                },
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
 	}
 }
 


### PR DESCRIPTION
Expose a new `raw` attribute for onefuse_static_property_sets which
contains the raw JSON of the SPS. This can be parsed into an Object with
`jsondecode` to access nested values.

The SPS `properties` attribute is still avaliable for accessing simple
string:string top-level key:value pairs.

The workflow for accessing nested SPS values goes like this:

```
// Static Property Set
// We expect a Static Property Set called SPS01 with the following content:
// {
//   "someKey": "someValue",
//   "parent": {
//     "someNestedKey": "someNestedValue"
//   }
// }
//
data "onefuse_static_property_set" "sps01" {
    name = "SPS01"
}

locals  {
  some_nested_value = jsondecode(data.onefuse_static_property_set.sps01.raw).parent.someNestedKey
}

output "some_nested_value" {
  value = local.some_nested_value
}
```

The use of `local` is optional, one can directly use `jsondecode(...).some.property` directly.

Note: @rsmall1 this means we will be adding a new `raw` attribute to the `onefuse_static_property_set` data which is the raw JSON for a static property set.

This pull request is temporarily targeted to feature/OUP-15-Async-Support but should be merged into `develop` after that branch is merged.